### PR TITLE
feat: Improve fields for forced-colors high contrast modes

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1159,7 +1159,13 @@ button:hover,
     color: CanvasText;
   }
 
-  /* Checkboxes — replace native control, manual system-color styling */
+  /*
+   * Checkboxes — replace native control, manual system-color styling.
+   * Note: .toggle-label input[type="checkbox"] is restored to appearance: checkbox
+   * in the earlier forced-colors block with higher specificity (0,2,1).
+   * That ensures toggle switches keep the hidden native checkbox. Do not add rules here
+   * that match .toggle-label input[type="checkbox"] or the toggle will break.
+   */
   input[type="checkbox"],
   .checkbox-label input[type="checkbox"] {
     forced-color-adjust: none;


### PR DESCRIPTION
before:
<img width="1213" height="998" alt="Skærmbillede 2026-02-28 kl  14 01 08" src="https://github.com/user-attachments/assets/e124b104-f101-4a46-b981-c96c356b685d" />

after:
<img width="1213" height="998" alt="Skærmbillede 2026-02-28 kl  14 01 16" src="https://github.com/user-attachments/assets/ed81c666-0b13-4e34-966d-6f44587c03df" />
