### PR TITLE
fix: Fix childless group nodes rendering as leaves in explorer tree

### DIFF
--- a/app/views/groups/_tree_node.html.haml
+++ b/app/views/groups/_tree_node.html.haml
@@ -35,11 +35,8 @@
             - else
               %span.tree__label= profile.name
 - else
-  %li.tree__folder{role: "treeitem"}
-    .tree__row
-      %span.tree__arrow-btn{"aria-hidden": "true"}
-        %span.tree__arrow
-      = link_to group_path(group.uuid), class: "tree__item", "data-action": "click->tree#selectGroup", "data-panel-url": panel_group_path(group.uuid), "data-group-uuid": group.uuid do
-        - if group.avatar.attached?
-          = image_tag group.avatar.variant(resize_to_fill: [24, 24]), class: "tree__avatar", width: 24, height: 24, alt: ""
-        %span.tree__label= group.name
+  %li.tree__leaf{role: "treeitem"}
+    = link_to group_path(group.uuid), class: "tree__item", "data-action": "click->tree#selectGroup", "data-panel-url": panel_group_path(group.uuid), "data-group-uuid": group.uuid do
+      - if group.avatar.attached?
+        = image_tag group.avatar.variant(resize_to_fill: [24, 24]), class: "tree__avatar", width: 24, height: 24, alt: ""
+      %span.tree__label= group.name


### PR DESCRIPTION
Groups with no children or profiles were rendered as `tree__folder` with an empty `.tree__arrow-btn`, leaving a blank gap instead of the connector line. Change the no-children branch to use `tree__leaf`, which gets the horizontal guide line via the existing `::after` rule and the correct left-padding via `.tree__leaf`.