### PR TITLE
fix: Always show the shared theme edit button to admins

### DIFF
--- a/app/views/our/themes/_shared_theme_card.html.haml
+++ b/app/views/our/themes/_shared_theme_card.html.haml
@@ -9,7 +9,7 @@
     .card__actions
       = link_to "Preview", our_theme_path(theme), class: "btn btn--small btn--secondary"
       = link_to "Duplicate", duplicate_our_theme_path(theme), data: { turbo_method: :post }, class: "btn btn--small btn--secondary"
-      - if Current.user.admin? && theme.user_id == Current.user.id
+      - if Current.user.admin?
         = link_to "Edit", edit_our_theme_path(theme), class: "btn btn--small btn--secondary"
   - if theme.credit.present? || theme.credit_url.present? || theme.notes.present?
     .card__body


### PR DESCRIPTION
regardless of whether they created it