### PR TITLE
fix: Show immediate sub-groups on the public group page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,6 +3,7 @@ class GroupsController < ApplicationController
     @group = Group.find_by!(uuid: params[:uuid])
     @group_theme = @group.theme
     @direct_profiles = @group.visible_root_profiles
+    @direct_child_groups = @group.visible_direct_child_groups
     @seen_profile_ids = Set.new
     @descendant_tree = @group.descendant_tree(seen_profile_ids: @seen_profile_ids)
   end
@@ -15,10 +16,16 @@ class GroupsController < ApplicationController
       root_group = Group.find_by!(uuid: params[:root])
       path = Array(params[:path]).map(&:to_i)
       @profiles = @group.profiles_visible_at_path(path, root_group_id: root_group.id)
+      @sub_groups = @group.visible_direct_child_groups(path: path, root_group_id: root_group.id)
+      @root_uuid = params[:root]
+      @current_path = path
     else
       @profiles = @group.visible_root_profiles
+      @sub_groups = @group.visible_direct_child_groups
+      @root_uuid = @group.uuid
+      @current_path = []
     end
 
-    render partial: "groups/group_content", locals: { group: @group, profiles: @profiles }, layout: false
+    render partial: "groups/group_content", locals: { group: @group, profiles: @profiles, sub_groups: @sub_groups, root_uuid: @root_uuid, current_path: @current_path }, layout: false
   end
 end

--- a/app/javascript/controllers/tree_controller.js
+++ b/app/javascript/controllers/tree_controller.js
@@ -34,10 +34,7 @@ export default class extends Controller {
   selectGroup(event) {
     event.preventDefault()
     const link = event.currentTarget
-    this.#clearActive()
-    link.classList.add("tree__item--active")
-    this.#setHash("group", link.dataset.groupUuid)
-    this.#loadPanelAndScroll(link.dataset.panelUrl)
+    this.#selectGroupItem(link)
   }
 
   toggleFolder(event) {
@@ -72,6 +69,35 @@ export default class extends Controller {
   }
 
   // --- private ---
+
+  #selectGroupItem(link) {
+    const { panelUrl, groupUuid } = link.dataset
+
+    this.#clearActive()
+
+    // If the clicked element is already a tree item, highlight it directly.
+    // Otherwise (e.g. a group card in the content panel), find the matching tree item.
+    const treeItem = link.classList.contains("tree__item")
+      ? link
+      : this.element.querySelector(`.tree .tree__item[data-group-uuid="${groupUuid}"]`)
+
+    if (treeItem) {
+      treeItem.classList.add("tree__item--active")
+      // Ensure parent folders are expanded so the item is visible
+      let parent = treeItem.closest(".tree__children")
+      while (parent) {
+        parent.style.display = ""
+        const folder = parent.closest(".tree__folder")
+        if (folder) folder.setAttribute("aria-expanded", "true")
+        const arrowBtn = parent.previousElementSibling?.querySelector(".tree__arrow")
+        if (arrowBtn) arrowBtn.classList.add("tree__arrow--open")
+        parent = parent.parentElement?.closest(".tree__children")
+      }
+    }
+
+    this.#setHash("group", groupUuid)
+    this.#loadPanelAndScroll(panelUrl)
+  }
 
   #selectProfileButton(link) {
     const { panelUrl, groupUuid, profileUuid } = link.dataset
@@ -112,9 +138,7 @@ export default class extends Controller {
          .tree .tree__item[data-action*="selectRoot"][data-group-uuid="${parts[1]}"]`
       )
       if (link) {
-        this.#clearActive()
-        link.classList.add("tree__item--active")
-        this.#loadPanelAndScroll(link.dataset.panelUrl)
+        this.#selectGroupItem(link)
       }
     } else if (parts[0] === "profile" && parts[1] && parts[2]) {
       const link = this.element.querySelector(

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -349,7 +349,7 @@ class Group < ApplicationRecord
       .where(group_id: root_group_id, target_type: "Group")
       .where("path = ?::jsonb", path.to_json)
       .pluck(:target_id)
-    child_groups.where.not(id: hidden_ids).includes(avatar_attachment: :blob).order(:name)
+    child_groups.where.not(id: hidden_ids).includes(avatar_attachment: :blob).order_by_name_and_labels
   end
 
   # Collect all profiles from this group and all descendant groups,

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -340,6 +340,18 @@ class Group < ApplicationRecord
     profiles.where.not(id: hidden_profile_ids).order_by_name_and_labels
   end
 
+  # Direct child groups visible when this group is reached via a specific traversal path
+  # from root_group_id. Filters out groups hidden by inclusion overrides at the given path.
+  # path is an array of integer group IDs representing the traversal path to this group.
+  # For the root group itself, use path=[] and root_group_id=id (the defaults).
+  def visible_direct_child_groups(path: [], root_group_id: id)
+    hidden_ids = InclusionOverride
+      .where(group_id: root_group_id, target_type: "Group")
+      .where("path = ?::jsonb", path.to_json)
+      .pluck(:target_id)
+    child_groups.where.not(id: hidden_ids).includes(avatar_attachment: :blob).order(:name)
+  end
+
   # Collect all profiles from this group and all descendant groups,
   # respecting path-scoped inclusion overrides.
   # Walks the tree depth-first, checking overrides at each path.

--- a/app/views/groups/_group_card.html.haml
+++ b/app/views/groups/_group_card.html.haml
@@ -1,0 +1,13 @@
+-# Public group card for the explorer content panel.
+-# Locals: group (the sub-group), root_uuid, child_path
+= link_to group_path(group.uuid), class: "profile-card card", "data-action": "click->tree#selectGroup", "data-panel-url": panel_group_path(group.uuid, root: root_uuid, path: child_path), "data-group-uuid": group.uuid do
+  - if group.avatar.attached?
+    = image_tag group.avatar.variant(resize_to_fill: [64, 64]), class: "avatar #{avatar_shape_class(group)}".strip, width: 64, height: 64, alt: group.avatar_alt_text.presence || "", loading: "lazy"
+  - else
+    .avatar.avatar--placeholder
+      = render "shared/plural_pride_logo"
+  %h3= group.name
+  - if group.subtitle.present?
+    %p.subtitle= group.subtitle
+  - if group.tag_line.present?
+    %p.tag-line= group.tag_line

--- a/app/views/groups/_group_content.html.haml
+++ b/app/views/groups/_group_content.html.haml
@@ -1,5 +1,8 @@
 -# Group content panel for the explorer view.
--# Locals: group, profiles
+-# Locals: group, profiles, sub_groups (optional), root_uuid (optional), current_path (optional)
+- sub_groups = local_assigns.fetch(:sub_groups, [])
+- root_uuid = local_assigns.fetch(:root_uuid, group.uuid)
+- current_path = local_assigns.fetch(:current_path, [])
 .card.profile-public
   .card__header
     - if group.avatar.attached?
@@ -15,6 +18,11 @@
   - if group.description.present?
     .group-description{data: {controller: "spoiler", action: "click->spoiler#toggle keydown->spoiler#keydown"}}
       = formatted_description(group.description)
+
+- if sub_groups.any?
+  .profile-grid
+    - sub_groups.each do |sub_group|
+      = render "groups/group_card", group: sub_group, root_uuid: root_uuid, child_path: current_path + [sub_group.id]
 
 - if profiles.any?
   .profile-grid

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -57,7 +57,7 @@
 
       .explorer__content{"data-tree-target": "content", "aria-live": "polite"}
         -# Default: show root group content
-        = render "groups/group_content", group: @group, profiles: @direct_profiles
+        = render "groups/group_content", group: @group, profiles: @direct_profiles, sub_groups: @direct_child_groups, root_uuid: @group.uuid, current_path: []
 
     -# No-JS fallback: all content rendered flat with linked profile cards
     .explorer__fallback{"data-tree-target": "fallback"}

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -119,6 +119,53 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Ripple", response.body
   end
 
+  test "show renders direct child group cards in the content panel" do
+    alpha = groups(:alpha_clan)
+    get group_path(uuid: alpha.uuid)
+    assert_response :success
+    # Echo Shard and Spectrum are direct children — should appear as group cards
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:echo_shard).uuid}']" do
+      assert_select "h3", text: "Echo Shard"
+    end
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:spectrum).uuid}']" do
+      assert_select "h3", text: "Spectrum"
+    end
+  end
+
+  test "show does not render grandchild groups as direct cards" do
+    alpha = groups(:alpha_clan)
+    get group_path(uuid: alpha.uuid)
+    assert_response :success
+    # Prism Circle is a grandchild, not a direct child — must not appear as a card in root content
+    assert_select ".explorer__content a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:prism_circle).uuid}']", count: 0
+  end
+
+  test "panel returns direct child group cards" do
+    alpha = groups(:alpha_clan)
+    get panel_group_path(uuid: alpha.uuid)
+    assert_response :success
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:echo_shard).uuid}']"
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:spectrum).uuid}']"
+  end
+
+  test "panel returns child group cards when reached via path" do
+    flux = groups(:flux)
+    castle = groups(:castle_clan)
+    get panel_group_path(uuid: flux.uuid, root: castle.uuid, path: [ flux.id ])
+    assert_response :success
+    # Echo Shard is a child of Flux and not hidden
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:echo_shard).uuid}']"
+  end
+
+  test "panel hides child groups with a path-scoped override" do
+    flux = groups(:flux)
+    castle = groups(:castle_clan)
+    get panel_group_path(uuid: flux.uuid, root: castle.uuid, path: [ flux.id ])
+    assert_response :success
+    # Static Burst is hidden in Flux when reached via Castle Clan
+    assert_select "a[data-action='click->tree#selectGroup'][data-group-uuid='#{groups(:static_burst).uuid}']", count: 0
+  end
+
   test "show applies group theme CSS when group has a theme" do
     group = groups(:friends) # has theme: dark_forest
     get group_path(uuid: group.uuid)

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -179,6 +179,52 @@ class GroupTest < ActiveSupport::TestCase
     assert_not_includes friends.visible_root_profiles, alice
   end
 
+  # -- visible_direct_child_groups ---
+
+  test "visible_direct_child_groups returns direct child groups" do
+    alpha = groups(:alpha_clan)
+    children = alpha.visible_direct_child_groups
+    assert_includes children, groups(:echo_shard)
+    assert_includes children, groups(:spectrum)
+  end
+
+  test "visible_direct_child_groups does not return non-child groups" do
+    alpha = groups(:alpha_clan)
+    children = alpha.visible_direct_child_groups
+    assert_not_includes children, groups(:prism_circle)
+  end
+
+  test "visible_direct_child_groups excludes groups hidden at root path" do
+    alpha = groups(:alpha_clan)
+    echo = groups(:echo_shard)
+
+    InclusionOverride.create!(
+      group: alpha, path: [], target_type: "Group", target_id: echo.id
+    )
+
+    assert_not_includes alpha.visible_direct_child_groups, echo
+  end
+
+  test "visible_direct_child_groups excludes groups hidden at a nested path" do
+    castle = groups(:castle_clan)
+    flux = groups(:flux)
+    static_burst = groups(:static_burst)
+
+    # static_burst is hidden within flux when reached via castle_clan (path=[flux.id])
+    result = flux.visible_direct_child_groups(path: [ flux.id ], root_group_id: castle.id)
+    assert_not_includes result, static_burst
+  end
+
+  test "visible_direct_child_groups includes groups not matched by path-scoped override" do
+    castle = groups(:castle_clan)
+    flux = groups(:flux)
+    echo = groups(:echo_shard)
+
+    # echo_shard is a child of flux and NOT hidden — should still appear
+    result = flux.visible_direct_child_groups(path: [ flux.id ], root_group_id: castle.id)
+    assert_includes result, echo
+  end
+
   # -- descendant_tree ---
 
   test "descendant_tree returns empty array for leaf group" do

--- a/test/system/public_group_explorer_test.rb
+++ b/test/system/public_group_explorer_test.rb
@@ -1,0 +1,102 @@
+require "application_system_test_case"
+
+# Tests for sub-group cards on the public group explorer page.
+# Uses user :three / alpha_clan which has:
+#   alpha_clan
+#   ├── Echo Shard  (child group, contains Mirage)
+#   ├── Spectrum    (child group)
+#   └── Grove       (direct profile)
+class PublicGroupExplorerTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:three)
+    sign_in_via_browser
+  end
+
+  # ── Sub-group cards in the content panel ─────────────────────────────────
+
+  test "direct child group cards appear in the content panel" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      assert_selector ".profile-card h3", text: "Echo Shard"
+      assert_selector ".profile-card h3", text: "Spectrum"
+    end
+  end
+
+  test "profile cards also appear in the content panel alongside group cards" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      assert_selector ".profile-card h3", text: "Grove"
+    end
+  end
+
+  test "group cards appear before profile cards in the content panel" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      grids = all(".profile-grid")
+      within(grids[0]) { assert_text "Echo Shard" }
+      within(grids[1]) { assert_text "Grove" }
+    end
+  end
+
+  test "grandchild groups do not appear as cards in the root content panel" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      assert_no_selector ".profile-card h3", text: "Prism Circle"
+    end
+  end
+
+  # ── Clicking a sub-group card loads its content ───────────────────────────
+
+  test "clicking a sub-group card loads that group's content in the panel" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      find(".profile-card", text: "Echo Shard").click
+    end
+
+    within(".explorer__content") do
+      assert_selector "h1", text: "Echo Shard"
+      assert_selector ".profile-card h3", text: "Mirage"
+    end
+  end
+
+  # ── Clicking a sub-group card highlights the sidebar ─────────────────────
+
+  test "clicking a sub-group card highlights the matching sidebar tree item" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    within(".explorer__content") do
+      find(".profile-card", text: "Echo Shard").click
+    end
+
+    within(".explorer__sidebar") do
+      assert_selector ".tree__item--active[data-group-uuid='#{groups(:echo_shard).uuid}']"
+    end
+  end
+
+  test "clicking a sub-group card clears the previous active state" do
+    visit group_path(groups(:alpha_clan).uuid)
+
+    # Click Echo Shard first, then Spectrum — only Spectrum should be active
+    within(".explorer__content") do
+      find(".profile-card", text: "Echo Shard").click
+    end
+
+    within(".explorer__sidebar") do
+      assert_selector ".tree__item--active[data-group-uuid='#{groups(:echo_shard).uuid}']"
+    end
+
+    within(".explorer__sidebar") do
+      find(".tree__item[data-group-uuid='#{groups(:spectrum).uuid}']").click
+    end
+
+    within(".explorer__sidebar") do
+      assert_selector ".tree__item--active[data-group-uuid='#{groups(:spectrum).uuid}']"
+      assert_no_selector ".tree__item--active[data-group-uuid='#{groups(:echo_shard).uuid}']"
+    end
+  end
+end


### PR DESCRIPTION
Closes #230 